### PR TITLE
BE `CurrencyApiController`: allow `findBy` method's `query` param to be `null`

### DIFF
--- a/webapp/src/main/java/com/example/investotrack/webapp/controller/CurrencyApiController.java
+++ b/webapp/src/main/java/com/example/investotrack/webapp/controller/CurrencyApiController.java
@@ -25,7 +25,7 @@ public class CurrencyApiController {
     }
 
     @GetMapping("/find_by")
-    public Collection<CurrencyViewModel> findBy(@RequestParam("q") String query,
+    public Collection<CurrencyViewModel> findBy(@RequestParam(value = "q", required = false) String query,
                                                 @PathVariable @ValidApiVersion String version) {
         return currencyDataProviderService.findCaseInsensitiveCurrenciesBy(query);
     }

--- a/webapp/src/main/java/com/example/investotrack/webapp/service/CurrencyDataProviderService.java
+++ b/webapp/src/main/java/com/example/investotrack/webapp/service/CurrencyDataProviderService.java
@@ -2,6 +2,7 @@ package com.example.investotrack.webapp.service;
 
 
 import com.example.investotrack.webapp.viewmodel.CurrencyViewModel;
+import org.springframework.lang.Nullable;
 
 import java.util.Collection;
 
@@ -18,10 +19,11 @@ public interface CurrencyDataProviderService {
     Collection<CurrencyViewModel> listAllCurrencies();
 
     /**
-     * Case-insensitively finds specific currencies by the provided query.
+     * Case-insensitively finds specific currencies by the provided query. If no query has been provided, then tries to
+     * find all currencies.
      *
-     * @param query the case-insensitive string to look for in the currency data
+     * @param query the case-insensitive string to look for in the currency data, might be null
      * @return      a list of currencies or an empty collection if none were found
      */
-    Collection<CurrencyViewModel> findCaseInsensitiveCurrenciesBy(String query);
+    Collection<CurrencyViewModel> findCaseInsensitiveCurrenciesBy(@Nullable String query);
 }

--- a/webapp/src/main/java/com/example/investotrack/webapp/service/CurrencyDataProviderServiceImpl.java
+++ b/webapp/src/main/java/com/example/investotrack/webapp/service/CurrencyDataProviderServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.investotrack.dataprovidercore.CurrencyDataProvider;
 import com.example.investotrack.webapp.datastore.DataCache;
 import com.example.investotrack.webapp.viewmodel.CurrencyViewModel;
 import com.example.investotrack.webapp.viewmodel.convertor.CurrencyModelConvertor;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -38,7 +39,10 @@ class CurrencyDataProviderServiceImpl implements CurrencyDataProviderService {
     }
 
     @Override
-    public Collection<CurrencyViewModel> findCaseInsensitiveCurrenciesBy(String query) {
+    public Collection<CurrencyViewModel> findCaseInsensitiveCurrenciesBy(@Nullable String query) {
+        if (query == null || query.isBlank()) {
+            return listAllCurrencies().stream().toList();
+        }
         String ciq = query.toLowerCase(Locale.ROOT);
         return listAllCurrencies().stream()
                                   .filter(c -> lowerCased(c.name()).contains(ciq) ||

--- a/webapp/src/test/java/com/example/investotrack/webapp/service/CurrencyDataProviderServiceImplTest.java
+++ b/webapp/src/test/java/com/example/investotrack/webapp/service/CurrencyDataProviderServiceImplTest.java
@@ -128,4 +128,67 @@ class CurrencyDataProviderServiceImplTest {
         // Assert
         assertThat(result).containsExactly(btcViewModel, btcLiteViewModel);
     }
+
+    @Test
+    void findCaseInsensitiveCurrenciesBy_queryNull_returnsAllCoins() {
+        // Arrange
+        var btcViewModel = new CurrencyViewModel("btc", "btc", "Bitcoin");
+        var btcLiteViewModel = new CurrencyViewModel("btcLite", "btclite", "Bitcoin Lite");
+        var ethViewModel = new CurrencyViewModel("eth", "eth", "Ethereum");
+
+        when(dataCache.getOrSupply(anyString(),
+                                   anyString(),
+                                   ArgumentMatchers.<Supplier<Collection<CurrencyViewModel>>>any())).thenReturn(List.of(
+                btcViewModel,
+                btcLiteViewModel,
+                ethViewModel));
+
+        // Act
+        Collection<CurrencyViewModel> result = currencyDataProviderService.findCaseInsensitiveCurrenciesBy(null);
+
+        // Assert
+        assertThat(result).contains(btcViewModel, btcLiteViewModel, ethViewModel);
+    }
+
+    @Test
+    void findCaseInsensitiveCurrenciesBy_queryEmptyString_returnsAllCoins() {
+        // Arrange
+        var btcViewModel = new CurrencyViewModel("btc", "btc", "Bitcoin");
+        var btcLiteViewModel = new CurrencyViewModel("btcLite", "btclite", "Bitcoin Lite");
+        var ethViewModel = new CurrencyViewModel("eth", "eth", "Ethereum");
+
+        when(dataCache.getOrSupply(anyString(),
+                                   anyString(),
+                                   ArgumentMatchers.<Supplier<Collection<CurrencyViewModel>>>any())).thenReturn(List.of(
+                btcViewModel,
+                btcLiteViewModel,
+                ethViewModel));
+
+        // Act
+        Collection<CurrencyViewModel> result = currencyDataProviderService.findCaseInsensitiveCurrenciesBy("");
+
+        // Assert
+        assertThat(result).contains(btcViewModel, btcLiteViewModel, ethViewModel);
+    }
+
+    @Test
+    void findCaseInsensitiveCurrenciesBy_queryOnlyWhitespace_returnsAllCoins() {
+        // Arrange
+        var btcViewModel = new CurrencyViewModel("btc", "btc", "Bitcoin");
+        var btcLiteViewModel = new CurrencyViewModel("btcLite", "btclite", "Bitcoin Lite");
+        var ethViewModel = new CurrencyViewModel("eth", "eth", "Ethereum");
+
+        when(dataCache.getOrSupply(anyString(),
+                                   anyString(),
+                                   ArgumentMatchers.<Supplier<Collection<CurrencyViewModel>>>any())).thenReturn(List.of(
+                btcViewModel,
+                btcLiteViewModel,
+                ethViewModel));
+
+        // Act
+        Collection<CurrencyViewModel> result = currencyDataProviderService.findCaseInsensitiveCurrenciesBy(" ");
+
+        // Assert
+        assertThat(result).contains(btcViewModel, btcLiteViewModel, ethViewModel);
+    }
 }


### PR DESCRIPTION
It makes sense, as it's just a filter. It should've been nullable from start, but slipped through & remained untested.